### PR TITLE
Change ZincView script function to loadModel, set current directory

### DIFF
--- a/data/heart.zincview.py
+++ b/data/heart.zincview.py
@@ -1,6 +1,8 @@
 """
 Example ZincView model loading script.
 
+Must implement loadModel() function which must return True on success.
+
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -25,7 +27,7 @@ def getDefaultCoordinateField(fieldmodule):
         field = fielditer.next()
     return None
 
-def readFile(region):
+def loadModel(region):
     '''
     This function must be implemented and return True on success to be
     a valid ZincView script
@@ -43,9 +45,10 @@ def readFile(region):
     bob = fieldmodule.createFieldStringConstant("bob")
     bob.setName("bob")
     bob.setManaged(True)
-    coordinates_lambda = fieldmodule.createFieldComponent(coordinates, 1)
-    coordinates_lambda.setName("coordinates.lambda")
-    coordinates_lambda.setManaged(True)
+    for i in range(1, coordinates.getNumberOfComponents() + 1):
+        component = fieldmodule.createFieldComponent(coordinates, i)
+        component.setName(coordinates.getComponentName(i))
+        component.setManaged(True)
     rc_coordinates = fieldmodule.createFieldCoordinateTransformation(coordinates)
     rc_coordinates.setCoordinateSystemType(Field.COORDINATE_SYSTEM_TYPE_RECTANGULAR_CARTESIAN)
     direction = fieldmodule.createFieldConstant([0.8, 0.4, 0.1])

--- a/src/zincview.py
+++ b/src/zincview.py
@@ -7,13 +7,13 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
-import sys
 import math
+import os
+import sys
 from PySide import QtGui, QtCore
 from zincview_ui import Ui_ZincView
 from opencmiss.zinc.context import Context as ZincContext
 from opencmiss.zinc.status import OK as ZINC_OK
-#from opencmiss.zinc.element import Element
 from opencmiss.zinc.field import Field
 from opencmiss.zinc.sceneviewer import Sceneviewer, Sceneviewerevent
 
@@ -110,23 +110,26 @@ class ZincView(QtGui.QMainWindow):
         self.ui.scene_editor.setScene(scene)
         region.endHierarchicalChange()
  
-    def modelRead(self):
+    def modelLoad(self):
         '''
-        Read model file or script.
+        Read model file or run script to read or define model.
         '''
-        fileNameTuple = QtGui.QFileDialog.getOpenFileName(self, "Read ZincView Model", "", "Model Files (*.ex* *.fieldml);;ZincView scripts (*.zincview.py)");
+        fileNameTuple = QtGui.QFileDialog.getOpenFileName(self, "Load ZincView Model", "", "Model Files (*.ex* *.fieldml);;ZincView scripts (*.zincview.py)");
         fileName = fileNameTuple[0]
         fileFilter = fileNameTuple[1]
         if not fileName:
             return
         #print "reading file", fileName, ", filter", fileFilter
+        # set current directory to path from file, to support scripts and fieldml with external resources
+        path = os.path.dirname(fileName)
+        os.chdir(path)
         region = self._context.getDefaultRegion()
         if "scripts" in fileFilter:
             try:
                 f = open(fileName, 'r')
                 myfunctions = {}
                 exec f in myfunctions
-                success = myfunctions['readFile'](self._context.getDefaultRegion())
+                success = myfunctions['loadModel'](self._context.getDefaultRegion())
             except:
                 success = False
         else:

--- a/src/zincview.ui
+++ b/src/zincview.ui
@@ -197,7 +197,7 @@ QToolBox {
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="model_read_button">
+              <widget class="QPushButton" name="model_load_button">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -205,7 +205,7 @@ QToolBox {
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Read model...</string>
+                <string>Load model...</string>
                </property>
               </widget>
              </item>
@@ -468,6 +468,14 @@ QToolBox {
             </layout>
            </widget>
            <widget class="QWidget" name="rendering">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>228</width>
+              <height>507</height>
+             </rect>
+            </property>
             <attribute name="label">
              <string>Rendering</string>
             </attribute>
@@ -597,10 +605,10 @@ QToolBox {
    </hints>
   </connection>
   <connection>
-   <sender>model_read_button</sender>
+   <sender>model_load_button</sender>
    <signal>clicked()</signal>
    <receiver>ZincView</receiver>
-   <slot>modelRead()</slot>
+   <slot>modelLoad()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>57</x>
@@ -870,7 +878,7 @@ QToolBox {
   </connection>
  </connections>
  <slots>
-  <slot>modelRead()</slot>
+  <slot>modelLoad()</slot>
   <slot>viewAll()</slot>
   <slot>viewAngleEntered()</slot>
   <slot>lookatPointEntered()</slot>

--- a/src/zincview_ui.py
+++ b/src/zincview_ui.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'zincview.ui'
 #
-# Created: Thu May 14 13:33:10 2015
+# Created: Thu May 14 15:31:59 2015
 #      by: pyside-uic 0.2.15 running on PySide 1.2.1
 #
 # WARNING! All changes made in this file will be lost!
@@ -118,14 +118,14 @@ class Ui_ZincView(object):
         self.model_clear_button = QtGui.QPushButton(self.model)
         self.model_clear_button.setObjectName("model_clear_button")
         self.verticalLayout_4.addWidget(self.model_clear_button)
-        self.model_read_button = QtGui.QPushButton(self.model)
+        self.model_load_button = QtGui.QPushButton(self.model)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.model_read_button.sizePolicy().hasHeightForWidth())
-        self.model_read_button.setSizePolicy(sizePolicy)
-        self.model_read_button.setObjectName("model_read_button")
-        self.verticalLayout_4.addWidget(self.model_read_button)
+        sizePolicy.setHeightForWidth(self.model_load_button.sizePolicy().hasHeightForWidth())
+        self.model_load_button.setSizePolicy(sizePolicy)
+        self.model_load_button.setObjectName("model_load_button")
+        self.verticalLayout_4.addWidget(self.model_load_button)
         spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.verticalLayout_4.addItem(spacerItem)
         self.toolBox.addItem(self.model, "")
@@ -261,6 +261,7 @@ class Ui_ZincView(object):
         self.verticalLayout_5.addItem(spacerItem1)
         self.toolBox.addItem(self.view, "")
         self.rendering = QtGui.QWidget()
+        self.rendering.setGeometry(QtCore.QRect(0, 0, 228, 507))
         self.rendering.setObjectName("rendering")
         self.verticalLayout_7 = QtGui.QVBoxLayout(self.rendering)
         self.verticalLayout_7.setObjectName("verticalLayout_7")
@@ -314,7 +315,7 @@ class Ui_ZincView(object):
         self.toolBox.setCurrentIndex(0)
         self.toolBox.layout().setSpacing(1)
         QtCore.QObject.connect(self.view_angle, QtCore.SIGNAL("editingFinished()"), ZincView.viewAngleEntered)
-        QtCore.QObject.connect(self.model_read_button, QtCore.SIGNAL("clicked()"), ZincView.modelRead)
+        QtCore.QObject.connect(self.model_load_button, QtCore.SIGNAL("clicked()"), ZincView.modelLoad)
         QtCore.QObject.connect(self.view_all_button, QtCore.SIGNAL("clicked()"), ZincView.viewAll)
         QtCore.QObject.connect(self.eye_point, QtCore.SIGNAL("editingFinished()"), ZincView.eyePointEntered)
         QtCore.QObject.connect(self.lookat_point, QtCore.SIGNAL("editingFinished()"), ZincView.lookatPointEntered)
@@ -337,7 +338,7 @@ class Ui_ZincView(object):
         ZincView.setWindowTitle(QtGui.QApplication.translate("ZincView", "ZincView", None, QtGui.QApplication.UnicodeUTF8))
         self.dockWidget.setWindowTitle(QtGui.QApplication.translate("ZincView", "ZincView Tools", None, QtGui.QApplication.UnicodeUTF8))
         self.model_clear_button.setText(QtGui.QApplication.translate("ZincView", "Clear model...", None, QtGui.QApplication.UnicodeUTF8))
-        self.model_read_button.setText(QtGui.QApplication.translate("ZincView", "Read model...", None, QtGui.QApplication.UnicodeUTF8))
+        self.model_load_button.setText(QtGui.QApplication.translate("ZincView", "Load model...", None, QtGui.QApplication.UnicodeUTF8))
         self.toolBox.setItemText(self.toolBox.indexOf(self.model), QtGui.QApplication.translate("ZincView", "Model", None, QtGui.QApplication.UnicodeUTF8))
         self.toolBox.setItemText(self.toolBox.indexOf(self.graphics), QtGui.QApplication.translate("ZincView", "Graphics", None, QtGui.QApplication.UnicodeUTF8))
         self.view_all_button.setText(QtGui.QApplication.translate("ZincView", "View All", None, QtGui.QApplication.UnicodeUTF8))


### PR DESCRIPTION
Change ZincView script function to loadModel() and also label on
ZincView widget to reflect that script doesn't necessarily need to read
a model e.g. it could just define fields or model via Zinc API.
Set current directory to path from input file so scripts and fieldml models with
external resources can work.
